### PR TITLE
add `add-to-project` workflow and starter workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,21 @@
+name: Add issue/pr to CrowdStrike Github project
+
+on:
+  workflow_call:
+    inputs:
+      project_number:
+        required: true
+        type: number
+    secrets:
+      ADD_TO_PROJECT_PAT:
+        required: true
+
+jobs:
+  add-to-project:
+    name: Add to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/CrowdStrike/projects/${{ inputs.project_number}}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/workflow-templates/add-to-project.properties.json
+++ b/workflow-templates/add-to-project.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "Add issue/pr to CrowdStrike Project Board",
+  "description": "Adds a issue or pr to a CrowdStrike Github project board."
+}

--- a/workflow-templates/add-to-project.yml
+++ b/workflow-templates/add-to-project.yml
@@ -1,0 +1,19 @@
+name: Add issue/pr to CrowdStrike Github project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+env:
+  PROJECT_NUMBER: MY_PROJECT_NUMBER # set this to the CrowdStrike project you want to add the issue/pr to    
+
+jobs:
+  add-to-github-project:
+    uses: crowdstrike/.github/.github/workflows/add-to-project.yml@main
+    with:
+      project_number: ${{ env.PROJECT_NUMBER }} 
+    secrets:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
We are using github boards to keep track of issues and pr's in github.

This PR does the following:

- creates a reusable workflow that will be responsible for adding a issue/pr to a github project
- a starter workflow that calls the reusable workflow that will be exposed to the org that will make consuming the reusable workflow easier.


#3 needs to be resolved too